### PR TITLE
Updated exec.rs to increase portability of code

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -29,7 +29,7 @@ pub fn exec(executable: &str, args: Vec<&str>) -> Result<(), UECOError> {
     // Build null terminated array with pointers null terminated c-strings
     let mut args_nl = args.iter()
         .map(|cs| cs.as_ptr())
-        .collect::<Vec<* const i8>>();
+        .collect::<Vec<* const libc::c_char>>();
     args_nl.push(std::ptr::null());
 
 


### PR DESCRIPTION
Changed cast from i8 to libc::c_char, which may be aliased to i8 depending on architecture.